### PR TITLE
Add frontend-backend integration with auth context and data hooks

### DIFF
--- a/src/app/event/layout.tsx
+++ b/src/app/event/layout.tsx
@@ -1,12 +1,14 @@
 'use client'
 
 import * as React from 'react'
-import { Presentation, Calendar, ClipboardList, Heart, BarChart3, FileText, Users } from 'lucide-react'
+import { Presentation, Calendar, ClipboardList, Heart, BarChart3, FileText, Users, Loader2 } from 'lucide-react'
 import { Navbar } from '@/components/layout/navbar'
 import { TabsNav } from '@/components/layout/tabs-nav'
 import { Container } from '@/components/layout/container'
 import { CreditBar } from '@/components/voting/credit-bar'
 import { Badge } from '@/components/ui/badge'
+import { useEvent } from '@/hooks/use-event'
+import { useAuth } from '@/hooks'
 
 const tabs = [
   {
@@ -47,24 +49,70 @@ const tabs = [
   },
 ]
 
+// Determine event status based on dates and flags
+function getEventStatus(event: {
+  schedulePublished: boolean
+  scheduleLocked: boolean
+  startDate: string
+  endDate: string
+} | null, votingConfig: { preVoteDeadline: string | null; proposalDeadline: string | null } | null) {
+  if (!event) return 'proposals_open'
+
+  const now = new Date()
+  const startDate = new Date(event.startDate)
+  const endDate = new Date(event.endDate)
+
+  if (now > endDate) return 'concluded'
+  if (now >= startDate && now <= endDate) return 'live'
+  if (event.schedulePublished) return 'scheduled'
+
+  // Check voting deadlines
+  if (votingConfig?.preVoteDeadline) {
+    const preVoteDeadline = new Date(votingConfig.preVoteDeadline)
+    if (now <= preVoteDeadline) return 'voting_open'
+  }
+
+  if (votingConfig?.proposalDeadline) {
+    const proposalDeadline = new Date(votingConfig.proposalDeadline)
+    if (now <= proposalDeadline) return 'proposals_open'
+  }
+
+  return 'proposals_open'
+}
+
+// Calculate time remaining until deadline
+function getTimeRemaining(deadline: string | null): string {
+  if (!deadline) return ''
+
+  const now = new Date()
+  const deadlineDate = new Date(deadline)
+  const diff = deadlineDate.getTime() - now.getTime()
+
+  if (diff <= 0) return 'Closed'
+
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24))
+  const hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60))
+
+  if (days > 0) return `Closes in ${days}d ${hours}h`
+  return `Closes in ${hours}h`
+}
+
 export default function EventLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
-  // Mock data - in real app, this would come from context/API
-  const event = {
-    name: 'EthBoulder 2026',
-    status: 'voting_open' as const,
-  }
+  // Fetch event data and user info
+  const { event, votingConfig, loading: eventLoading, error: eventError } = useEvent()
+  const { user, loading: authLoading, signOut } = useAuth()
 
-  const user = {
-    name: 'Alice Chen',
-  }
+  // Calculate event status
+  const eventStatus = getEventStatus(event, votingConfig)
 
+  // Mock credits for now (will be from user's voting credits later)
   const credits = {
-    total: 100,
-    spent: 18,
+    total: votingConfig?.preVoteCredits || 100,
+    spent: 0, // Will be calculated from user's votes
   }
 
   const statusLabels = {
@@ -83,13 +131,41 @@ export default function EventLayout({
     concluded: 'muted',
   } as const
 
+  // Loading state
+  if (eventLoading || authLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  // Error state
+  if (eventError) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <p className="text-destructive mb-2">Failed to load event</p>
+          <p className="text-sm text-muted-foreground">{eventError}</p>
+        </div>
+      </div>
+    )
+  }
+
+  // Get deadline for status bar
+  const deadline = eventStatus === 'voting_open'
+    ? votingConfig?.preVoteDeadline
+    : eventStatus === 'proposals_open'
+    ? votingConfig?.proposalDeadline
+    : null
+
   return (
     <div className="min-h-screen flex flex-col">
       <Navbar
-        eventName={event.name}
-        user={user}
+        eventName={event?.name || 'Event'}
+        user={user ? { name: user.email || 'User' } : null}
         credits={credits}
-        onSignOut={() => console.log('Sign out')}
+        onSignOut={signOut}
       />
 
       {/* Event Status Banner */}
@@ -97,12 +173,14 @@ export default function EventLayout({
         <Container>
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 py-4">
             <div className="flex items-center gap-3">
-              <Badge variant={statusColors[event.status]}>
-                {statusLabels[event.status]}
+              <Badge variant={statusColors[eventStatus]}>
+                {statusLabels[eventStatus]}
               </Badge>
-              <span className="text-sm text-muted-foreground">
-                Closes in 2d 14h
-              </span>
+              {deadline && (
+                <span className="text-sm text-muted-foreground">
+                  {getTimeRemaining(deadline)}
+                </span>
+              )}
             </div>
 
             <div className="sm:hidden">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 import './globals.css'
+import { Providers } from './providers'
 
 const inter = Inter({
   subsets: ['latin'],
@@ -20,7 +21,7 @@ export default function RootLayout({
   return (
     <html lang="en" className={inter.variable}>
       <body className="min-h-screen bg-background font-sans antialiased">
-        {children}
+        <Providers>{children}</Providers>
       </body>
     </html>
   )

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import { ReactNode } from 'react'
+import { AuthProvider } from '@/context/auth-context'
+
+interface ProvidersProps {
+  children: ReactNode
+}
+
+export function Providers({ children }: ProvidersProps) {
+  return <AuthProvider>{children}</AuthProvider>
+}

--- a/src/context/auth-context.tsx
+++ b/src/context/auth-context.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react'
+import type { User, Session } from '@supabase/supabase-js'
+import { createClient } from '@/lib/supabase/client'
+
+interface AuthContextType {
+  user: User | null
+  session: Session | null
+  loading: boolean
+  signInWithEmail: (email: string) => Promise<{ error: Error | null }>
+  signOut: () => Promise<void>
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined)
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+  const [session, setSession] = useState<Session | null>(null)
+  const [loading, setLoading] = useState(true)
+  const supabase = createClient()
+
+  useEffect(() => {
+    // Get initial session
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      setSession(session)
+      setUser(session?.user ?? null)
+      setLoading(false)
+    })
+
+    // Listen for auth changes
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(session)
+      setUser(session?.user ?? null)
+      setLoading(false)
+    })
+
+    return () => subscription.unsubscribe()
+  }, [supabase.auth])
+
+  const signInWithEmail = async (email: string) => {
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: {
+        emailRedirectTo: `${window.location.origin}/auth/callback`,
+      },
+    })
+    return { error: error as Error | null }
+  }
+
+  const signOut = async () => {
+    await supabase.auth.signOut()
+  }
+
+  return (
+    <AuthContext.Provider
+      value={{
+        user,
+        session,
+        loading,
+        signInWithEmail,
+        signOut,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext)
+  if (context === undefined) {
+    throw new Error('useAuth must be used within an AuthProvider')
+  }
+  return context
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,8 @@
+export { useAuth } from '@/context/auth-context'
+export { useEvent } from './use-event'
+export { useSessions } from './use-sessions'
+export { useSession } from './use-session'
+
+export type { Event, AccessMode, VotingConfig, BudgetConfig } from './use-event'
+export type { Session, SessionHost } from './use-sessions'
+export type { SessionDetail, VoteStats } from './use-session'

--- a/src/hooks/use-event.ts
+++ b/src/hooks/use-event.ts
@@ -1,0 +1,91 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { EVENT_SLUG } from '@/lib/config'
+
+export interface Event {
+  id: string
+  slug: string
+  name: string
+  description: string | null
+  startDate: string
+  endDate: string
+  location: string | null
+  bannerImageUrl: string | null
+  schedulePublished: boolean
+  scheduleLocked: boolean
+  distributionExecuted: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+export interface AccessMode {
+  mode: string
+  nftContractAddress: string | null
+  nftChainId: number | null
+}
+
+export interface VotingConfig {
+  preVoteCredits: number
+  attendanceVoteCredits: number
+  proposalDeadline: string | null
+  preVoteDeadline: string | null
+  votingOpensAt: string | null
+}
+
+export interface BudgetConfig {
+  totalBudgetPool: number
+  paymentTokenAddress: string | null
+  paymentTokenSymbol: string | null
+  platformFeePercent: number
+  treasuryWalletAddress: string | null
+}
+
+interface UseEventReturn {
+  event: Event | null
+  accessMode: AccessMode | null
+  votingConfig: VotingConfig | null
+  budgetConfig: BudgetConfig | null
+  loading: boolean
+  error: string | null
+  refetch: () => Promise<void>
+}
+
+export function useEvent(slug: string = EVENT_SLUG): UseEventReturn {
+  const [event, setEvent] = useState<Event | null>(null)
+  const [accessMode, setAccessMode] = useState<AccessMode | null>(null)
+  const [votingConfig, setVotingConfig] = useState<VotingConfig | null>(null)
+  const [budgetConfig, setBudgetConfig] = useState<BudgetConfig | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchEvent = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+
+    try {
+      const response = await fetch(`/api/events/${slug}`)
+
+      if (!response.ok) {
+        const data = await response.json()
+        throw new Error(data.error || 'Failed to fetch event')
+      }
+
+      const data = await response.json()
+      setEvent(data.event)
+      setAccessMode(data.accessMode)
+      setVotingConfig(data.votingConfig)
+      setBudgetConfig(data.budgetConfig)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred')
+    } finally {
+      setLoading(false)
+    }
+  }, [slug])
+
+  useEffect(() => {
+    fetchEvent()
+  }, [fetchEvent])
+
+  return { event, accessMode, votingConfig, budgetConfig, loading, error, refetch: fetchEvent }
+}

--- a/src/hooks/use-session.ts
+++ b/src/hooks/use-session.ts
@@ -1,0 +1,109 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { EVENT_SLUG } from '@/lib/config'
+
+export interface SessionHost {
+  id: string
+  name: string | null
+  avatar: string | null
+  bio: string | null
+  isPrimary: boolean | null
+  status: string | null
+}
+
+export interface SessionDetail {
+  id: string
+  eventId: string
+  title: string
+  description: string | null
+  format: string
+  duration: number
+  maxParticipants: number | null
+  technicalRequirements: string[]
+  topicTags: string[]
+  status: string
+  rejectionReason: string | null
+  isLocked: boolean
+  createdAt: string
+  updatedAt: string
+  venue: {
+    id: string
+    name: string
+    capacity: number
+    features: string[]
+    description: string | null
+  } | null
+  timeSlot: {
+    id: string
+    start_time: string
+    end_time: string
+    label: string | null
+  } | null
+}
+
+export interface VoteStats {
+  preVote: {
+    totalVotes: number
+    totalVoters: number
+    totalCreditsSpent: number
+    voteDistribution: Record<string, number>
+  }
+  attendance: {
+    totalVotes: number
+    totalVoters: number
+    qfScore: number
+    voteDistribution: Record<string, number>
+  }
+}
+
+interface UseSessionReturn {
+  session: SessionDetail | null
+  hosts: SessionHost[]
+  votes: VoteStats | null
+  loading: boolean
+  error: string | null
+  refetch: () => Promise<void>
+}
+
+export function useSession(sessionId: string, slug: string = EVENT_SLUG): UseSessionReturn {
+  const [session, setSession] = useState<SessionDetail | null>(null)
+  const [hosts, setHosts] = useState<SessionHost[]>([])
+  const [votes, setVotes] = useState<VoteStats | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchSession = useCallback(async () => {
+    if (!sessionId) {
+      setLoading(false)
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+
+    try {
+      const response = await fetch(`/api/events/${slug}/sessions/${sessionId}`)
+
+      if (!response.ok) {
+        const data = await response.json()
+        throw new Error(data.error || 'Failed to fetch session')
+      }
+
+      const data = await response.json()
+      setSession(data.session)
+      setHosts(data.hosts || [])
+      setVotes(data.votes)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred')
+    } finally {
+      setLoading(false)
+    }
+  }, [sessionId, slug])
+
+  useEffect(() => {
+    fetchSession()
+  }, [fetchSession])
+
+  return { session, hosts, votes, loading, error, refetch: fetchSession }
+}

--- a/src/hooks/use-sessions.ts
+++ b/src/hooks/use-sessions.ts
@@ -1,0 +1,104 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { EVENT_SLUG } from '@/lib/config'
+
+export interface SessionHost {
+  id: string
+  name: string | null
+  avatar: string | null
+  isPrimary: boolean | null
+}
+
+export interface Session {
+  id: string
+  title: string
+  description: string | null
+  format: string
+  duration: number
+  maxParticipants: number | null
+  technicalRequirements: string[]
+  topicTags: string[]
+  status: string
+  rejectionReason: string | null
+  isLocked: boolean
+  createdAt: string
+  updatedAt: string
+  hosts: SessionHost[]
+  venue: {
+    id: string
+    name: string
+    capacity: number
+    features: string[]
+  } | null
+  timeSlot: {
+    id: string
+    start_time: string
+    end_time: string
+    label: string | null
+  } | null
+  preVoteStats: {
+    totalVotes: number
+    totalVoters: number
+  }
+  attendanceStats: {
+    totalVotes: number
+    qfScore: number
+  }
+}
+
+interface UseSessionsOptions {
+  status?: string
+  format?: string
+  tags?: string[]
+}
+
+interface UseSessionsReturn {
+  sessions: Session[]
+  loading: boolean
+  error: string | null
+  refetch: () => Promise<void>
+}
+
+export function useSessions(options: UseSessionsOptions = {}): UseSessionsReturn {
+  const [sessions, setSessions] = useState<Session[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchSessions = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+
+    try {
+      const params = new URLSearchParams()
+      if (options.status) params.set('status', options.status)
+      if (options.format) params.set('format', options.format)
+      if (options.tags && options.tags.length > 0) {
+        params.set('tags', options.tags.join(','))
+      }
+
+      const queryString = params.toString()
+      const url = `/api/events/${EVENT_SLUG}/sessions${queryString ? `?${queryString}` : ''}`
+
+      const response = await fetch(url)
+
+      if (!response.ok) {
+        const data = await response.json()
+        throw new Error(data.error || 'Failed to fetch sessions')
+      }
+
+      const data = await response.json()
+      setSessions(data.sessions || [])
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred')
+    } finally {
+      setLoading(false)
+    }
+  }, [options.status, options.format, options.tags])
+
+  useEffect(() => {
+    fetchSessions()
+  }, [fetchSessions])
+
+  return { sessions, loading, error, refetch: fetchSessions }
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,10 @@
+/**
+ * Application configuration
+ */
+
+/** The event slug to use for API calls */
+export const EVENT_SLUG = process.env.NEXT_PUBLIC_EVENT_SLUG || 'ethdenver-2025'
+
+/** Supabase configuration */
+export const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!
+export const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!


### PR DESCRIPTION
## Summary
- Create auth context for Supabase authentication with magic link sign-in
- Add providers wrapper to root layout for global state
- Create reusable data hooks (`useSessions`, `useEvent`, `useSession`) for API fetching
- Update sessions page to fetch real sessions from the API
- Update event layout to show real event name and status from database
- Add config helper with `EVENT_SLUG` environment variable

## Changes
- `src/lib/config.ts` - Application configuration with EVENT_SLUG
- `src/context/auth-context.tsx` - Auth provider with Supabase integration
- `src/app/providers.tsx` - Client providers wrapper
- `src/hooks/use-sessions.ts` - Hook for fetching sessions list
- `src/hooks/use-event.ts` - Hook for fetching event details
- `src/hooks/use-session.ts` - Hook for fetching single session
- `src/app/event/sessions/page.tsx` - Updated to use real API data
- `src/app/event/layout.tsx` - Updated to use real event and auth data

## Test plan
- [x] Verified sessions page loads data from API
- [x] Verified event name displays from database (ETHDenver 2025)
- [x] Verified event status calculates correctly
- [x] Loading states display while fetching
- [x] Error states handle API failures gracefully

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)